### PR TITLE
11 add syracuse platform linking signal 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   - Add platform key extraction from provider settings
   - Improve logging for platform linking process
   - Add error handling for platform linking failures
+  - Fix signal handling for admin interface actions:
+    - Add custom admin class to properly trigger signals
+    - Add explicit signal sending for admin actions
+    - Improve logging for signal handling debugging
   - Add comprehensive test coverage:
     - Test provider configuration retrieval
     - Test platform key extraction

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # ChangeLog
 
+## 2.0.8
+- Add automatic platform linking for Azure AD users:
+  - Add signal handler to monitor social auth creation
+  - Add utility functions for provider configuration management
+  - Add management command for linking existing users to platforms
+  - Add configurable AZURE_PROVIDER setting (defaults to 'azuread-oauth2')
+  - Add platform key extraction from provider settings
+  - Improve logging for platform linking process
+  - Add error handling for platform linking failures
+  - Add comprehensive test coverage:
+    - Test provider configuration retrieval
+    - Test platform key extraction
+    - Test custom provider settings
+    - Test management command functionality
+    - Test signal handler behavior
+    - Test error handling scenarios
+    - Test provider filtering
+
 ## 2.0.7
 - Improve Apple ID authentication logging and security:
   - Add consistent state value masking (showing first 8 characters)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # ChangeLog
 
 ## 2.0.8
-- Add automatic platform linking for Azure AD users:
+- Add automatic platform linking for provider users:
   - Add signal handler to monitor social auth creation
   - Add utility functions for provider configuration management
   - Add management command for linking existing users to platforms
-  - Add configurable AZURE_PROVIDER setting (defaults to 'azuread-oauth2')
+  - Add configurable MONITORED_PROVIDERS setting (defaults to ['azuread-oauth2'])
   - Add platform key extraction from provider settings
   - Improve logging for platform linking process
   - Add error handling for platform linking failures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.0.8
 - Add automatic platform linking for provider users:
-  - Add signal handler to monitor social auth creation
+  - Add signal handler to monitor social auth creation and updates
+  - Add support for admin interface actions
   - Add utility functions for provider configuration management
   - Add management command for linking existing users to platforms
   - Add configurable MONITORED_PROVIDERS setting (defaults to ['azuread-oauth2'])

--- a/USAGE.md
+++ b/USAGE.md
@@ -280,3 +280,59 @@ This process needs to be repeated for each `LMS` and `CMS` domain that exists.
 - Logging into the CMS first will result in a "Page Not Found" because it will try to redirect to a `registration` url
     - User's who have a keycloak account but haven't created their edx account should always login through the LMS first
 - Logging into the LMS could present the user with additional fields to fill out, depending on what's passed via the id token (given name, family name, etc) and how the `REGISTRATION_EXTRA_FIELDS` is configured.
+
+## Azure AD Platform Linking
+This feature automatically links users authenticated through Azure AD to their corresponding platform in the Manager API.
+
+### Configuration
+
+1. In your OAuth2 Provider Configuration, add the platform key to the other_settings:
+```json
+{
+    "platform_key": "your_platform_key",
+    "backend_uri": "/auth/login/azuread-oauth2",
+    // ... other settings ...
+}
+```
+
+2. (Optional) Configure the monitored provider name in your settings:
+```python
+# In your OpenEdX settings
+AZURE_PROVIDER = 'azuread-oauth2'  # This is the default if not specified
+```
+
+### Automatic Linking
+When a user authenticates through Azure AD:
+1. A UserSocialAuth record is created
+2. The system automatically retrieves the platform_key from the provider configuration
+3. The user is automatically linked to the platform using the Manager API
+
+### Manual Linking (Management Command)
+For users that were created before the automatic linking was implemented, you can use the management command:
+
+```bash
+# Link all existing users from a specific provider to their platform
+python manage.py link_provider_users_to_platform azuread-oauth2
+```
+
+The command will:
+- Find all users with social auth links from the specified provider
+- Get the platform_key from the provider's configuration
+- Attempt to link each user to the platform
+- Provide progress updates and a final summary
+
+### Response Codes
+The platform linking process may return the following status codes:
+- 200: User was already linked to the platform
+- 201: User was successfully linked to the platform
+- 400: Bad parameters
+- 500: Platform link failed
+
+### Logging
+The system logs all platform linking activities:
+- New social auth creation
+- Platform key retrieval
+- Linking attempts and results
+- Any errors during the process
+
+Logs can be monitored through your standard OpenEdX logging configuration.

--- a/USAGE.md
+++ b/USAGE.md
@@ -281,8 +281,8 @@ This process needs to be repeated for each `LMS` and `CMS` domain that exists.
     - User's who have a keycloak account but haven't created their edx account should always login through the LMS first
 - Logging into the LMS could present the user with additional fields to fill out, depending on what's passed via the id token (given name, family name, etc) and how the `REGISTRATION_EXTRA_FIELDS` is configured.
 
-## Azure AD Platform Linking
-This feature automatically links users authenticated through Azure AD to their corresponding platform in the Manager API.
+## Platform Linking
+This feature automatically links users authenticated through configured providers to their corresponding platform in the Manager API.
 
 ### Configuration
 
@@ -295,44 +295,14 @@ This feature automatically links users authenticated through Azure AD to their c
 }
 ```
 
-2. (Optional) Configure the monitored provider name in your settings:
+2. (Optional) Configure the monitored providers in your settings:
 ```python
 # In your OpenEdX settings
-AZURE_PROVIDER = 'azuread-oauth2'  # This is the default if not specified
+MONITORED_PROVIDERS = ['azuread-oauth2', 'other-provider']  # Defaults to ['azuread-oauth2'] if not specified
 ```
 
 ### Automatic Linking
-When a user authenticates through Azure AD:
+When a user authenticates through any monitored provider:
 1. A UserSocialAuth record is created
 2. The system automatically retrieves the platform_key from the provider configuration
 3. The user is automatically linked to the platform using the Manager API
-
-### Manual Linking (Management Command)
-For users that were created before the automatic linking was implemented, you can use the management command:
-
-```bash
-# Link all existing users from a specific provider to their platform
-python manage.py link_provider_users_to_platform azuread-oauth2
-```
-
-The command will:
-- Find all users with social auth links from the specified provider
-- Get the platform_key from the provider's configuration
-- Attempt to link each user to the platform
-- Provide progress updates and a final summary
-
-### Response Codes
-The platform linking process may return the following status codes:
-- 200: User was already linked to the platform
-- 201: User was successfully linked to the platform
-- 400: Bad parameters
-- 500: Platform link failed
-
-### Logging
-The system logs all platform linking activities:
-- New social auth creation
-- Platform key retrieval
-- Linking attempts and results
-- Any errors during the process
-
-Logs can be monitored through your standard OpenEdX logging configuration.

--- a/USAGE.md
+++ b/USAGE.md
@@ -312,10 +312,10 @@ For existing users who were created before the automatic linking was implemented
 
 ```bash
 # Link users from a specific provider
-python manage.py link_provider_users_to_platform azuread-oauth2
+python ./manage.py lms link_provider_users_to_platform azuread-oauth2
 
 # Link users from all monitored providers
-python manage.py link_provider_users_to_platform
+python ./manage.py lms link_provider_users_to_platform
 ```
 
 The command will:

--- a/USAGE.md
+++ b/USAGE.md
@@ -306,3 +306,20 @@ When a user authenticates through any monitored provider:
 1. A UserSocialAuth record is created
 2. The system automatically retrieves the platform_key from the provider configuration
 3. The user is automatically linked to the platform using the Manager API
+
+### Management Command
+For existing users who were created before the automatic linking was implemented, you can use the management command to link them to their platforms:
+
+```bash
+# Link users from a specific provider
+python manage.py link_provider_users_to_platform azuread-oauth2
+
+# Link users from all monitored providers
+python manage.py link_provider_users_to_platform
+```
+
+The command will:
+- Find all users with social auth links from the specified provider(s)
+- Get the platform_key from each provider's configuration
+- Attempt to link each user to their corresponding platform
+- Provide progress updates and a final summary for each provider

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, roots):
 
 setup(
     name="ibl-third-party-auth",
-    version="2.0.7",
+    version="2.0.8",
     install_requires=[
         "ddt",
         "social-auth-app-django",

--- a/src/ibl_third_party_auth/admin.py
+++ b/src/ibl_third_party_auth/admin.py
@@ -1,0 +1,20 @@
+from django.contrib import admin
+from social_django.admin import UserSocialAuthOption
+from social_django.models import UserSocialAuth
+
+
+class IBLUserSocialAuthAdmin(UserSocialAuthOption):
+    """
+    Custom admin for UserSocialAuth that ensures our signal handler is triggered
+    for admin actions.
+    """
+
+    def save_model(self, request, obj, form, change):
+        # Store the action type in the request object
+        request._social_auth_action = "change" if change else "addition"
+        super().save_model(request, obj, form, change)
+
+
+# Unregister the default admin and register our custom one
+admin.site.unregister(UserSocialAuth)
+admin.site.register(UserSocialAuth, IBLUserSocialAuthAdmin)

--- a/src/ibl_third_party_auth/admin.py
+++ b/src/ibl_third_party_auth/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db.models import signals
 from social_django.admin import UserSocialAuthOption
 from social_django.models import UserSocialAuth
 
@@ -10,9 +11,42 @@ class IBLUserSocialAuthAdmin(UserSocialAuthOption):
     """
 
     def save_model(self, request, obj, form, change):
+        """
+        Given a model instance save it to the database.
+        """
         # Store the action type in the request object
         request._social_auth_action = "change" if change else "addition"
-        super().save_model(request, obj, form, change)
+
+        # Get the original instance if this is an update
+        if change:
+            original = UserSocialAuth.objects.get(pk=obj.pk)
+        else:
+            original = None
+
+        # Save the model
+        obj.save()
+
+        # Explicitly send the signal
+        if not change:
+            signals.post_save.send(
+                sender=UserSocialAuth,
+                instance=obj,
+                created=True,
+                raw=False,
+                using=None,
+                update_fields=None,
+                request=request,
+            )
+        else:
+            signals.post_save.send(
+                sender=UserSocialAuth,
+                instance=obj,
+                created=False,
+                raw=False,
+                using=None,
+                update_fields=None,
+                request=request,
+            )
 
 
 # Unregister the default admin and register our custom one

--- a/src/ibl_third_party_auth/apps.py
+++ b/src/ibl_third_party_auth/apps.py
@@ -74,3 +74,6 @@ class IBLThirdPartyAuthConfig(AppConfig):
 
         except Exception as e:
             log.error(f"Error during patching: {str(e)}", exc_info=True)
+
+        # Import signal handlers
+        import ibl_third_party_auth.signals  # noqa

--- a/src/ibl_third_party_auth/management/__init__.py
+++ b/src/ibl_third_party_auth/management/__init__.py
@@ -1,0 +1,1 @@
+# Empty init file

--- a/src/ibl_third_party_auth/management/commands/__init__.py
+++ b/src/ibl_third_party_auth/management/commands/__init__.py
@@ -1,0 +1,1 @@
+# Empty init file

--- a/src/ibl_third_party_auth/management/commands/link_provider_users_to_platform.py
+++ b/src/ibl_third_party_auth/management/commands/link_provider_users_to_platform.py
@@ -4,6 +4,7 @@ import logging
 from django.core.management.base import BaseCommand
 
 from ibl_third_party_auth.utils.provider_utils import (
+    get_monitored_providers,
     get_provider_config_by_backend,
     get_social_auth_users_by_provider,
 )
@@ -13,91 +14,110 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = "Links users from a specific provider to their corresponding platform using the Manager API"
+    help = "Links users from specific providers to their corresponding platform using the Manager API"
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "provider", type=str, help="The provider name (e.g., azuread-oauth2)"
+            "provider",
+            type=str,
+            nargs="?",  # Make the provider argument optional
+            help="The provider name (e.g., azuread-oauth2). If not provided, processes all monitored providers",
         )
 
     def handle(self, *args, **options):
         provider_name = options["provider"]
 
-        # Get provider configuration
-        provider_config = get_provider_config_by_backend(provider_name)
-        if not provider_config:
-            self.stderr.write(
-                self.style.ERROR(
-                    f"No enabled provider configuration found for {provider_name}"
-                )
-            )
-            return
+        # If no provider specified, get all monitored providers
+        providers_to_process = (
+            [provider_name] if provider_name else get_monitored_providers()
+        )
 
-        # Get platform key from provider config
-        try:
-            other_settings = json.loads(provider_config.other_settings)
-            platform_key = other_settings.get("platform_key")
-            if not platform_key:
+        for provider in providers_to_process:
+            self.stdout.write(f"\nProcessing provider: {provider}")
+
+            # Get provider configuration
+            provider_config = get_provider_config_by_backend(provider)
+            if not provider_config:
                 self.stderr.write(
-                    self.style.ERROR("No platform_key found in provider configuration")
+                    self.style.ERROR(
+                        f"No enabled provider configuration found for {provider}"
+                    )
                 )
-                return
-        except json.JSONDecodeError:
-            self.stderr.write(
-                self.style.ERROR("Invalid JSON in provider other_settings")
-            )
-            return
-        except Exception as e:
-            self.stderr.write(
-                self.style.ERROR(f"Error reading provider configuration: {str(e)}")
-            )
-            return
+                continue
 
-        # Get all users for this provider
-        social_auth_users = get_social_auth_users_by_provider(provider_name)
-        total_users = social_auth_users.count()
-
-        if total_users == 0:
-            self.stdout.write(
-                self.style.WARNING(f"No users found for provider {provider_name}")
-            )
-            return
-
-        self.stdout.write(f"Found {total_users} users for provider {provider_name}")
-
-        # Process each user
-        success_count = 0
-        error_count = 0
-
-        for index, social_auth in enumerate(social_auth_users, 1):
-            user_id = social_auth.user.id
-
-            self.stdout.write(f"Processing [{index}/{total_users}] User ID: {user_id}")
-
+            # Get platform key from provider config
             try:
-                result = link_user_to_platform(user_id, platform_key)
-                if result:
-                    success_count += 1
-                    self.stdout.write(
-                        self.style.SUCCESS(
-                            f"Successfully linked user {user_id} to platform {platform_key}"
+                other_settings = json.loads(provider_config.other_settings)
+                platform_key = other_settings.get("platform_key")
+                if not platform_key:
+                    self.stderr.write(
+                        self.style.ERROR(
+                            f"No platform_key found in provider configuration for {provider}"
                         )
                     )
-                else:
+                    continue
+            except json.JSONDecodeError:
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"Invalid JSON in provider other_settings for {provider}"
+                    )
+                )
+                continue
+            except Exception as e:
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"Error reading provider configuration for {provider}: {str(e)}"
+                    )
+                )
+                continue
+
+            # Get all users for this provider
+            social_auth_users = get_social_auth_users_by_provider(provider)
+            total_users = social_auth_users.count()
+
+            if total_users == 0:
+                self.stdout.write(
+                    self.style.WARNING(f"No users found for provider {provider}")
+                )
+                continue
+
+            self.stdout.write(f"Found {total_users} users for provider {provider}")
+
+            # Process each user
+            success_count = 0
+            error_count = 0
+
+            for index, social_auth in enumerate(social_auth_users, 1):
+                user_id = social_auth.user.id
+
+                self.stdout.write(
+                    f"Processing [{index}/{total_users}] User ID: {user_id}"
+                )
+
+                try:
+                    result = link_user_to_platform(user_id, platform_key)
+                    if result:
+                        success_count += 1
+                        self.stdout.write(
+                            self.style.SUCCESS(
+                                f"Successfully linked user {user_id} to platform {platform_key}"
+                            )
+                        )
+                    else:
+                        error_count += 1
+                        self.stdout.write(
+                            self.style.ERROR(
+                                f"Failed to link user {user_id} to platform {platform_key}"
+                            )
+                        )
+                except Exception as e:
                     error_count += 1
                     self.stdout.write(
-                        self.style.ERROR(
-                            f"Failed to link user {user_id} to platform {platform_key}"
-                        )
+                        self.style.ERROR(f"Error processing user {user_id}: {str(e)}")
                     )
-            except Exception as e:
-                error_count += 1
-                self.stdout.write(
-                    self.style.ERROR(f"Error processing user {user_id}: {str(e)}")
-                )
 
-        # Final summary
-        self.stdout.write("\nOperation completed:")
-        self.stdout.write(f"Total users processed: {total_users}")
-        self.stdout.write(self.style.SUCCESS(f"Successful links: {success_count}"))
-        self.stdout.write(self.style.ERROR(f"Failed links: {error_count}"))
+            # Summary for this provider
+            self.stdout.write(f"\nProvider {provider} completed:")
+            self.stdout.write(f"Total users processed: {total_users}")
+            self.stdout.write(self.style.SUCCESS(f"Successful links: {success_count}"))
+            self.stdout.write(self.style.ERROR(f"Failed links: {error_count}"))

--- a/src/ibl_third_party_auth/management/commands/link_provider_users_to_platform.py
+++ b/src/ibl_third_party_auth/management/commands/link_provider_users_to_platform.py
@@ -1,0 +1,103 @@
+import json
+import logging
+
+from django.core.management.base import BaseCommand
+
+from ibl_third_party_auth.utils.provider_utils import (
+    get_provider_config_by_backend,
+    get_social_auth_users_by_provider,
+)
+from ibl_third_party_auth.utils.user_platform_link import link_user_to_platform
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Links users from a specific provider to their corresponding platform using the Manager API"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "provider", type=str, help="The provider name (e.g., azuread-oauth2)"
+        )
+
+    def handle(self, *args, **options):
+        provider_name = options["provider"]
+
+        # Get provider configuration
+        provider_config = get_provider_config_by_backend(provider_name)
+        if not provider_config:
+            self.stderr.write(
+                self.style.ERROR(
+                    f"No enabled provider configuration found for {provider_name}"
+                )
+            )
+            return
+
+        # Get platform key from provider config
+        try:
+            other_settings = json.loads(provider_config.other_settings)
+            platform_key = other_settings.get("platform_key")
+            if not platform_key:
+                self.stderr.write(
+                    self.style.ERROR("No platform_key found in provider configuration")
+                )
+                return
+        except json.JSONDecodeError:
+            self.stderr.write(
+                self.style.ERROR("Invalid JSON in provider other_settings")
+            )
+            return
+        except Exception as e:
+            self.stderr.write(
+                self.style.ERROR(f"Error reading provider configuration: {str(e)}")
+            )
+            return
+
+        # Get all users for this provider
+        social_auth_users = get_social_auth_users_by_provider(provider_name)
+        total_users = social_auth_users.count()
+
+        if total_users == 0:
+            self.stdout.write(
+                self.style.WARNING(f"No users found for provider {provider_name}")
+            )
+            return
+
+        self.stdout.write(f"Found {total_users} users for provider {provider_name}")
+
+        # Process each user
+        success_count = 0
+        error_count = 0
+
+        for index, social_auth in enumerate(social_auth_users, 1):
+            user_id = social_auth.user.id
+
+            self.stdout.write(f"Processing [{index}/{total_users}] User ID: {user_id}")
+
+            try:
+                result = link_user_to_platform(user_id, platform_key)
+                if result:
+                    success_count += 1
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            f"Successfully linked user {user_id} to platform {platform_key}"
+                        )
+                    )
+                else:
+                    error_count += 1
+                    self.stdout.write(
+                        self.style.ERROR(
+                            f"Failed to link user {user_id} to platform {platform_key}"
+                        )
+                    )
+            except Exception as e:
+                error_count += 1
+                self.stdout.write(
+                    self.style.ERROR(f"Error processing user {user_id}: {str(e)}")
+                )
+
+        # Final summary
+        self.stdout.write("\nOperation completed:")
+        self.stdout.write(f"Total users processed: {total_users}")
+        self.stdout.write(self.style.SUCCESS(f"Successful links: {success_count}"))
+        self.stdout.write(self.style.ERROR(f"Failed links: {error_count}"))

--- a/src/ibl_third_party_auth/signals.py
+++ b/src/ibl_third_party_auth/signals.py
@@ -1,11 +1,19 @@
 import logging
 from importlib import import_module
 
-from django.conf import settings
-from django.dispatch import receiver
-
 from common.djangoapps.student.models import UserProfile
+from django.conf import settings
 from django.contrib.auth.signals import user_logged_in, user_logged_out
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from social_django.models import UserSocialAuth
+
+from ibl_third_party_auth.utils.provider_utils import (
+    get_monitored_provider,
+    get_platform_key_from_provider,
+    get_provider_config_by_backend,
+)
+from ibl_third_party_auth.utils.user_platform_link import link_user_to_platform
 
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore  # pylint: disable=invalid-name
 log = logging.getLogger(__name__)
@@ -13,7 +21,7 @@ log = logging.getLogger(__name__)
 
 @receiver(user_logged_in)
 @receiver(user_logged_out)
-def cms_enforce_single_login(sender, request, user, signal, **kwargs):    # pylint: disable=unused-argument
+def cms_enforce_single_login(sender, request, user, signal, **kwargs):  # pylint: disable=unused-argument
     """
     Sets the current session id in the user profile,
     to prevent concurrent logins within the CMS only
@@ -27,15 +35,14 @@ def cms_enforce_single_login(sender, request, user, signal, **kwargs):    # pyli
     https://github.com/edx/edx-platform/blob/open-release/ironwood.master/common/djangoapps/student/models.py#L2260-L2278
 
     """
-    if getattr(settings, 'IBL_CMS_PREVENT_CONCURRENT_LOGINS', False):
+    if getattr(settings, "IBL_CMS_PREVENT_CONCURRENT_LOGINS", False):
         if signal == user_logged_in:
             key = request.session.session_key
         else:
             key = None
         if user:
             user_profile, __ = UserProfile.objects.get_or_create(
-                user=user,
-                defaults={'name': user.username}
+                user=user, defaults={"name": user.username}
             )
             if user_profile:
                 set_cms_login_session(user_profile, key)
@@ -48,9 +55,65 @@ def set_cms_login_session(profile, session_id=None):
     deletes the old session object.
     """
     meta = profile.get_meta()
-    old_login = meta.get('cms_session_id', None)
+    old_login = meta.get("cms_session_id", None)
     if old_login:
         SessionStore(session_key=old_login).delete()
-    meta['cms_session_id'] = session_id
+    meta["cms_session_id"] = session_id
     profile.set_meta(meta)
     profile.save()
+
+
+@receiver(post_save, sender=UserSocialAuth)
+def handle_social_auth_creation(sender, instance, created, **kwargs):
+    """
+    Signal handler to automatically link users to platforms when their social auth account is created.
+
+    Args:
+        sender: The model class (UserSocialAuth)
+        instance: The actual UserSocialAuth instance
+        created (bool): True if this is a new instance
+        **kwargs: Additional keyword arguments
+    """
+    if not created:
+        return
+
+    monitored_provider = get_monitored_provider()
+
+    # Check if this is the provider we want to monitor
+    if instance.provider != monitored_provider:
+        return
+
+    log.info(
+        f"New social auth created for user {instance.user.id} with provider {instance.provider}"
+    )
+
+    # Get provider configuration
+    provider_config = get_provider_config_by_backend(instance.provider)
+    if not provider_config:
+        log.error(f"No provider configuration found for {instance.provider}")
+        return
+
+    # Get platform key from provider config
+    platform_key = get_platform_key_from_provider(provider_config)
+    if not platform_key:
+        log.error("Could not get platform key from provider configuration")
+        return
+
+    # Link user to platform
+    try:
+        result = link_user_to_platform(instance.user.id, platform_key)
+        if result:
+            log.info(
+                f"Successfully linked user {instance.user.id} to platform {platform_key} "
+                f"after social auth creation"
+            )
+        else:
+            log.error(
+                f"Failed to link user {instance.user.id} to platform {platform_key} "
+                f"after social auth creation"
+            )
+    except Exception as e:
+        log.exception(
+            f"Error linking user {instance.user.id} to platform {platform_key} "
+            f"after social auth creation: {str(e)}"
+        )

--- a/src/ibl_third_party_auth/signals.py
+++ b/src/ibl_third_party_auth/signals.py
@@ -9,7 +9,7 @@ from django.dispatch import receiver
 from social_django.models import UserSocialAuth
 
 from ibl_third_party_auth.utils.provider_utils import (
-    get_monitored_provider,
+    get_monitored_providers,
     get_platform_key_from_provider,
     get_provider_config_by_backend,
 )
@@ -77,10 +77,10 @@ def handle_social_auth_creation(sender, instance, created, **kwargs):
     if not created:
         return
 
-    monitored_provider = get_monitored_provider()
+    monitored_providers = get_monitored_providers()
 
-    # Check if this is the provider we want to monitor
-    if instance.provider != monitored_provider:
+    # Check if this is one of the providers we want to monitor
+    if instance.provider not in monitored_providers:
         return
 
     log.info(

--- a/src/ibl_third_party_auth/signals.py
+++ b/src/ibl_third_party_auth/signals.py
@@ -76,15 +76,23 @@ def handle_social_auth_creation(sender, instance, created, **kwargs):
         created (bool): True if this is a new instance
         **kwargs: Additional keyword arguments
     """
+    log.info(
+        f"Signal received for UserSocialAuth - Created: {created}, "
+        f"Provider: {instance.provider}, User ID: {instance.user.id}"
+    )
+
     # Get the current action from request if available (for admin actions)
     request = kwargs.get("request")
     if request and hasattr(request, "_social_auth_action"):
         action = request._social_auth_action
+        log.info(f"Admin action detected: {action}")
     else:
         action = ADDITION if created else CHANGE
+        log.info(f"Non-admin action detected: {action}")
 
     # Only process for new instances or admin updates
     if not (created or action == CHANGE):
+        log.info("Skipping - not a new instance or admin update")
         return
 
     monitored_providers = get_monitored_providers()

--- a/src/ibl_third_party_auth/utils/provider_utils.py
+++ b/src/ibl_third_party_auth/utils/provider_utils.py
@@ -51,11 +51,33 @@ def get_platform_key_from_provider(provider_config):
         return None
 
 
-def get_monitored_provider():
+def get_monitored_providers():
     """
-    Get the provider name that should be monitored for social auth creation.
+    Get the list of provider names that should be monitored for social auth creation.
 
     Returns:
-        str: The provider name to monitor (defaults to 'azuread-oauth2')
+        list: List of provider names to monitor. Defaults to ['azuread-oauth2'] if not specified
     """
-    return getattr(settings, "AZURE_PROVIDER", "azuread-oauth2")
+    default_providers = ["azuread-oauth2"]
+    providers = getattr(settings, "MONITORED_PROVIDERS", default_providers)
+
+    # Handle string input for backward compatibility
+    if isinstance(providers, str):
+        providers = [providers]
+
+    return providers
+
+
+def get_social_auth_users_by_provider(provider):
+    """
+    Get all UserSocialAuth entries for a specific provider.
+
+    Args:
+        provider (str): The provider name (e.g., 'azuread-oauth2')
+
+    Returns:
+        QuerySet: A queryset of UserSocialAuth objects
+    """
+    from social_django.models import UserSocialAuth
+
+    return UserSocialAuth.objects.filter(provider=provider)

--- a/src/ibl_third_party_auth/utils/provider_utils.py
+++ b/src/ibl_third_party_auth/utils/provider_utils.py
@@ -2,22 +2,60 @@ import json
 import logging
 
 from common.djangoapps.third_party_auth.models import OAuth2ProviderConfig
+from django.conf import settings
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
-class IBLProviderConfig():
+
+def get_provider_config_by_backend(backend_name):
     """
-    Get the provider config for the given provider.
+    Get the most recent enabled provider config for a given backend name.
+
+    Args:
+        backend_name (str): The name of the backend (e.g., 'azuread-oauth2')
+
+    Returns:
+        OAuth2ProviderConfig: The most recent enabled provider config, or None if not found
     """
-    def get_audience(self, backend):
-        """
-        Get the audience for the given provider.
-        """
-        try:
-            provider = OAuth2ProviderConfig.objects.filter(slug=backend).latest('change_date')
-            provider_config = json.loads(provider.other_settings)
-            audience = provider_config.get('AUDIENCE')
-            return audience
-        except OAuth2ProviderConfig.DoesNotExist:
-            log.error("Provider not found")
-            return {}
+    try:
+        provider = OAuth2ProviderConfig.objects.filter(
+            backend_name=backend_name, enabled=True
+        ).latest("change_date")
+        return provider
+    except OAuth2ProviderConfig.DoesNotExist:
+        logger.error(f"No enabled provider config found for backend: {backend_name}")
+        return None
+
+
+def get_platform_key_from_provider(provider_config):
+    """
+    Extract platform key from provider's other_settings.
+
+    Args:
+        provider_config (OAuth2ProviderConfig): The provider configuration object
+
+    Returns:
+        str: The platform key if found, None otherwise
+    """
+    try:
+        other_settings = json.loads(provider_config.other_settings)
+        platform_key = other_settings.get("platform_key")
+        if not platform_key:
+            logger.error("No platform_key found in provider configuration")
+        return platform_key
+    except json.JSONDecodeError:
+        logger.error("Invalid JSON in provider other_settings")
+        return None
+    except Exception as e:
+        logger.error(f"Error reading provider configuration: {str(e)}")
+        return None
+
+
+def get_monitored_provider():
+    """
+    Get the provider name that should be monitored for social auth creation.
+
+    Returns:
+        str: The provider name to monitor (defaults to 'azuread-oauth2')
+    """
+    return getattr(settings, "AZURE_PROVIDER", "azuread-oauth2")

--- a/src/ibl_third_party_auth/utils/provider_utils.py
+++ b/src/ibl_third_party_auth/utils/provider_utils.py
@@ -3,8 +3,75 @@ import logging
 
 from common.djangoapps.third_party_auth.models import OAuth2ProviderConfig
 from django.conf import settings
+from django.contrib.auth import get_user_model
+from social_core.backends.oauth import BaseOAuth2
+from social_django.utils import load_strategy
 
 logger = logging.getLogger(__name__)
+
+User = get_user_model()
+
+
+class IBLProviderConfig:
+    """
+    Get the provider config for the given provider.
+    """
+
+    def get_audience(self, backend):
+        """
+        Get the audience for the given provider.
+        """
+        try:
+            provider = OAuth2ProviderConfig.objects.filter(slug=backend).latest(
+                "change_date"
+            )
+            provider_config = json.loads(provider.other_settings)
+            audience = provider_config.get("AUDIENCE")
+            return audience
+        except OAuth2ProviderConfig.DoesNotExist:
+            logger.error("Provider not found")
+            return {}
+
+    def get_provider_slug_by_platform_key(username, platform_key):
+        """
+        Find the provider slug based on the username and platform_key.
+
+        Args:
+        username (str): The username of the user.
+        platform_key (str): The platform key to match in the provider's other_settings.
+
+        Returns:
+        str: The slug of the matching provider, or None if no match is found.
+        """
+        logger.info(
+            f"Searching for provider slug with username: {username} and platform_key: {platform_key}"
+        )
+
+        try:
+            user = User.objects.get(username=username)
+            logger.info(f"User found: {user}")
+        except User.DoesNotExist:
+            logger.warning(f"User not found with username: {username}")
+            return None
+
+        strategy = load_strategy()
+        backends = strategy.get_backends().values()
+        logger.info(f"Loaded {len(backends)} backends")
+
+        for backend in backends:
+            if isinstance(backend, BaseOAuth2):
+                logger.debug(f"Checking backend: {backend.name}")
+                other_settings = getattr(backend, "other_settings", {})
+                backend_platform_key = other_settings.get("platform_key")
+                logger.debug(
+                    f"Backend {backend.name} platform_key: {backend_platform_key}"
+                )
+                if backend_platform_key == platform_key:
+                    logger.info(f"Matching provider found: {backend.name}")
+                    return backend.name
+
+        logger.warning(f"No matching provider found for platform_key: {platform_key}")
+        return None
 
 
 def get_provider_config_by_backend(backend_name):

--- a/src/ibl_third_party_auth/utils/user_platform_link.py
+++ b/src/ibl_third_party_auth/utils/user_platform_link.py
@@ -1,0 +1,48 @@
+import logging
+
+from ibl_request_router.api.manager import manager_api_request
+
+logger = logging.getLogger(__name__)
+
+
+def link_user_to_platform(user_id, platform_key):
+    """
+    Links a user to a platform using the Manager API.
+
+    Args:
+    user_id (str): The ID of the user to link.
+    platform_key (str): The platform key to link the user to.
+
+    Returns:
+    bool: True if the linking was successful (status code 200 or 201), False otherwise.
+    """
+    endpoint_path = "/core/users/platforms/"  # The function manager_api_request already appends /api to the Manager URLs
+    data = {
+        "user_id": user_id,
+        "platform_key": platform_key,
+    }
+    logger.info(f"Linking user {user_id} to platform {platform_key}")
+    try:
+        response = manager_api_request("POST", endpoint_path, data=data)
+        logger.info(f"Response: {response}")
+
+        if response and response.status_code in [200, 201]:
+            status_message = (
+                "already existed" if response.status_code == 200 else "created"
+            )
+            logger.info(
+                f"Successfully linked user {user_id} to platform {platform_key} "
+                f"(status: {status_message})"
+            )
+            return True
+        else:
+            logger.error(
+                f"Failed to link user {user_id} to platform {platform_key}. "
+                f"Status code: {response.status_code if response else 'No response'}"
+            )
+            return False
+    except Exception as e:
+        logger.exception(
+            f"Error linking user {user_id} to platform {platform_key}: {str(e)}"
+        )
+        return False

--- a/tests/test_platform_linking.py
+++ b/tests/test_platform_linking.py
@@ -1,0 +1,115 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from common.djangoapps.third_party_auth.models import OAuth2ProviderConfig
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from ibl_third_party_auth.management.commands.link_provider_users_to_platform import (
+    Command,
+)
+from ibl_third_party_auth.utils.provider_utils import (
+    get_monitored_provider,
+    get_platform_key_from_provider,
+    get_provider_config_by_backend,
+)
+from social_django.models import UserSocialAuth
+
+User = get_user_model()
+
+
+class TestPlatformLinking(TestCase):
+    """Tests for the platform linking functionality."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_user(username="testuser", password="testpass")
+        self.provider_config = OAuth2ProviderConfig.objects.create(
+            name="Azure AD",
+            slug="azuread-oauth2",
+            backend_name="azuread-oauth2",
+            enabled=True,
+            other_settings=json.dumps(
+                {
+                    "platform_key": "test_platform",
+                    "backend_uri": "/auth/login/azuread-oauth2",
+                }
+            ),
+        )
+        self.social_auth = UserSocialAuth.objects.create(
+            user=self.user, provider="azuread-oauth2", uid="12345"
+        )
+
+    def test_get_provider_config(self):
+        """Test getting provider configuration."""
+        config = get_provider_config_by_backend("azuread-oauth2")
+        self.assertIsNotNone(config)
+        self.assertEqual(config.slug, "azuread-oauth2")
+
+    def test_get_platform_key(self):
+        """Test extracting platform key from provider config."""
+        platform_key = get_platform_key_from_provider(self.provider_config)
+        self.assertEqual(platform_key, "test_platform")
+
+    def test_get_platform_key_invalid_json(self):
+        """Test handling invalid JSON in provider config."""
+        self.provider_config.other_settings = "invalid json"
+        self.provider_config.save()
+        platform_key = get_platform_key_from_provider(self.provider_config)
+        self.assertIsNone(platform_key)
+
+    @override_settings(AZURE_PROVIDER="custom-provider")
+    def test_get_monitored_provider_custom(self):
+        """Test getting custom monitored provider from settings."""
+        provider = get_monitored_provider()
+        self.assertEqual(provider, "custom-provider")
+
+    def test_get_monitored_provider_default(self):
+        """Test getting default monitored provider."""
+        provider = get_monitored_provider()
+        self.assertEqual(provider, "azuread-oauth2")
+
+    @patch("ibl_third_party_auth.utils.user_platform_link.link_user_to_platform")
+    def test_management_command(self, mock_link):
+        """Test the management command for linking users."""
+        mock_link.return_value = True
+
+        command = Command()
+        command.handle(provider="azuread-oauth2")
+
+        mock_link.assert_called_once_with(self.user.id, "test_platform")
+
+    @patch("ibl_third_party_auth.utils.user_platform_link.link_user_to_platform")
+    def test_signal_handler(self, mock_link):
+        """Test the signal handler for new social auth creation."""
+        mock_link.return_value = True
+
+        # Create a new social auth to trigger the signal
+        new_user = User.objects.create_user(username="newuser", password="testpass")
+        UserSocialAuth.objects.create(
+            user=new_user, provider="azuread-oauth2", uid="67890"
+        )
+
+        mock_link.assert_called_once_with(new_user.id, "test_platform")
+
+    @patch("ibl_third_party_auth.utils.user_platform_link.link_user_to_platform")
+    def test_signal_handler_different_provider(self, mock_link):
+        """Test the signal handler ignores non-monitored providers."""
+        # Create a social auth with different provider
+        new_user = User.objects.create_user(username="newuser", password="testpass")
+        UserSocialAuth.objects.create(
+            user=new_user, provider="google-oauth2", uid="67890"
+        )
+
+        mock_link.assert_not_called()
+
+    @patch("ibl_third_party_auth.utils.user_platform_link.link_user_to_platform")
+    def test_signal_handler_linking_failure(self, mock_link):
+        """Test handling of linking failures in signal handler."""
+        mock_link.return_value = False
+
+        new_user = User.objects.create_user(username="newuser", password="testpass")
+        UserSocialAuth.objects.create(
+            user=new_user, provider="azuread-oauth2", uid="67890"
+        )
+
+        mock_link.assert_called_once_with(new_user.id, "test_platform")


### PR DESCRIPTION
## 2.0.8
- Add automatic platform linking for provider users:
  - Add signal handler to monitor social auth creation and updates
  - Add support for admin interface actions
  - Add utility functions for provider configuration management
  - Add management command for linking existing users to platforms
  - Add configurable MONITORED_PROVIDERS setting (defaults to ['azuread-oauth2'])
  - Add platform key extraction from provider settings
  - Improve logging for platform linking process
  - Add error handling for platform linking failures
  - Fix signal handling for admin interface actions:
    - Add custom admin class to properly trigger signals
    - Add explicit signal sending for admin actions
    - Improve logging for signal handling debugging
  - Add comprehensive test coverage:
    - Test provider configuration retrieval
    - Test platform key extraction
    - Test custom provider settings
    - Test management command functionality
    - Test signal handler behavior
    - Test error handling scenarios
    - Test provider filtering