### PR TITLE
16 add a flag to disable new user registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # ChangeLog
 
+## 2.1.0
+### Added
+- Add `SOCIAL_AUTH_DISABLE_USER_CREATION` flag to control user creation during SSO:
+  - Implement user creation control in Apple ID authentication flow
+  - Add comprehensive user existence verification:
+    - Check by email address
+    - Check by username (configurable via EMAIL_AS_USERNAME setting)
+    - Check by social auth provider UID
+  - Add detailed logging for authentication attempts:
+    - Log user verification checks
+    - Log successful matches
+    - Log creation attempts when disabled
+  - Implement clear error handling:
+    - Raise PermissionDenied with informative messages
+    - Guide users to contact support when needed
+  - Maintain backward compatibility:
+    - Allow existing users to continue logging in
+    - Preserve all authentication paths for existing users
+  - Update platform linking to respect user creation setting
+  - Add documentation for the new setting and its usage
+
 ## 2.0.9
 - Enhance Apple ID user detail retrieval:
   - Add `get_user_fullname` method to fetch user details by email

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ This document covers installation and backend setup. For customer facing usage a
 cd $(tutor config printroot)"/env/build/openedx/requirements
 git clone --branch koa-tutor-plugin https://gitlab.com/iblstudios/ibl-edx-third-party-auth.git
 
-#Enter the lms shell 
+#Enter the lms shell
 tutor local run lms bash
 pip install -e ../requirement/ibl-edx-third-party-auth
 ```
 
 #### Uninstall
 ```
-#Enter the lms shell 
+#Enter the lms shell
 tutor local run lms bash
 pip uninstall ibl_third_party_auth
 ```

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, roots):
 
 setup(
     name="ibl-third-party-auth",
-    version="2.0.9",
+    version="2.1.0",
     install_requires=[
         "ddt",
         "social-auth-app-django",

--- a/src/ibl_third_party_auth/apps.py
+++ b/src/ibl_third_party_auth/apps.py
@@ -53,21 +53,25 @@ class IBLThirdPartyAuthConfig(AppConfig):
         try:
             # Import all relevant modules
             from common.djangoapps.third_party_auth import appleid
-            from social_core.backends import apple
+            from social_core.backends import apple, azuread
 
             log.info(f"Current AppleIdAuth class: {appleid.AppleIdAuth}")
             log.info(f"Current social_core AppleIdAuth class: {apple.AppleIdAuth}")
+            log.info(f"Current AzureADOAuth2 class: {azuread.AzureADOAuth2}")
 
             from .patches.patch_apple_id import patch as patch_apple_id
+            from .patches.patch_azuread import patch as patch_azuread
             from .patches.patch_middleware import patch as patch_middleware
 
             # Apply patches
             patch_apple_id()
+            patch_azuread()
             patch_middleware()
 
             # Verify patches
             log.info(f"After patching appleid.AppleIdAuth: {appleid.AppleIdAuth}")
             log.info(f"After patching apple.AppleIdAuth: {apple.AppleIdAuth}")
+            log.info(f"After patching azuread.AzureADOAuth2: {azuread.AzureADOAuth2}")
 
             # We don't need to force reload the backend during app initialization
             # The backend will be loaded correctly when needed during requests

--- a/src/ibl_third_party_auth/apps.py
+++ b/src/ibl_third_party_auth/apps.py
@@ -53,25 +53,29 @@ class IBLThirdPartyAuthConfig(AppConfig):
         try:
             # Import all relevant modules
             from common.djangoapps.third_party_auth import appleid
-            from social_core.backends import apple, azuread
+            from social_core.backends import apple, azuread, google
 
             log.info(f"Current AppleIdAuth class: {appleid.AppleIdAuth}")
             log.info(f"Current social_core AppleIdAuth class: {apple.AppleIdAuth}")
             log.info(f"Current AzureADOAuth2 class: {azuread.AzureADOAuth2}")
+            log.info(f"Current GoogleOAuth2 class: {google.GoogleOAuth2}")
 
             from .patches.patch_apple_id import patch as patch_apple_id
             from .patches.patch_azuread import patch as patch_azuread
+            from .patches.patch_google import patch as patch_google
             from .patches.patch_middleware import patch as patch_middleware
 
             # Apply patches
             patch_apple_id()
             patch_azuread()
             patch_middleware()
+            patch_google()
 
             # Verify patches
             log.info(f"After patching appleid.AppleIdAuth: {appleid.AppleIdAuth}")
             log.info(f"After patching apple.AppleIdAuth: {apple.AppleIdAuth}")
             log.info(f"After patching azuread.AzureADOAuth2: {azuread.AzureADOAuth2}")
+            log.info(f"After patching google.GoogleOAuth2: {google.GoogleOAuth2}")
 
             # We don't need to force reload the backend during app initialization
             # The backend will be loaded correctly when needed during requests

--- a/src/ibl_third_party_auth/patches/patch_apple_id.py
+++ b/src/ibl_third_party_auth/patches/patch_apple_id.py
@@ -530,8 +530,8 @@ def patch():
         original_request_access_token = BaseOAuth2.request_access_token
 
         def patched_request_access_token(self, *args, **kwargs):
-            log.info(f"request_access_token called on {self.__class__}")
             if isinstance(self, IBLAppleIdAuth):
+                log.info(f"request_access_token called on {self.__class__}")
                 log.info("Using IBLAppleIdAuth implementation")
             return original_request_access_token(self, *args, **kwargs)
 

--- a/src/ibl_third_party_auth/patches/patch_apple_id.py
+++ b/src/ibl_third_party_auth/patches/patch_apple_id.py
@@ -75,6 +75,7 @@ import json
 import logging
 import time
 import uuid
+from typing import Any, Dict, List, Optional, Union
 
 import jwt
 from common.djangoapps.third_party_auth import appleid
@@ -91,16 +92,16 @@ from social_django.models import UserSocialAuth
 log = logging.getLogger(__name__)
 
 
-def verify_redis_cache():
+def verify_redis_cache() -> bool:
     """Verify that Django's cache backend is Redis."""
-    from django.conf import settings
-
     cache_backend = settings.CACHES.get("default", {}).get("BACKEND", "")
     if cache_backend == "django_redis.cache.RedisCache":
         log.info("Using Redis cache backend")
         return True
     else:
-        log.warning(f"Cache backend is not Redis (found: {cache_backend})")
+        log.warning(
+            "Cache backend is not Redis", extra={"cache_backend": cache_backend}
+        )
         return False
 
 
@@ -121,35 +122,46 @@ class IBLAppleIdAuth(AppleIdAuth):
     TOKEN_AUDIENCE = "https://appleid.apple.com"
     TOKEN_TTL_SEC = 6 * 30 * 24 * 60 * 60
 
-    def __init__(self, *args, **kwargs):
-        log.info("Starting Apple ID authentication flow")
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        log.info("Initializing Apple ID authentication")
         super().__init__(*args, **kwargs)
-        # Verify Redis cache on initialization
         verify_redis_cache()
 
-    def auth_complete(self, *args, **kwargs):
+    def auth_complete(self, *args: Any, **kwargs: Any) -> Any:
         """Complete the auth process."""
-        log.info("IBLAppleIdAuth.auth_complete called")
+        log.info("Starting auth completion process")
         try:
-            log.debug(f"Auth complete args: {args}")
-            log.debug(f"Auth complete kwargs: {kwargs}")
+            log.debug(
+                "Auth completion parameters",
+                extra={"args_length": len(args), "kwargs_keys": list(kwargs.keys())},
+            )
 
             response = super().auth_complete(*args, **kwargs)
-            log.info("Auth complete process successful")
+            log.info("Auth completion successful")
             return response
         except Exception as e:
-            log.error(f"Auth complete process failed: {str(e)}")
+            log.error(
+                "Auth completion failed",
+                extra={"error_type": type(e).__name__, "error_message": str(e)},
+            )
             if hasattr(e, "response"):
-                log.error(f"Response status: {e.response.status_code}")
-                log.error(f"Response content: {e.response.content}")
+                log.error(
+                    "Auth response details",
+                    extra={
+                        "status_code": e.response.status_code,
+                        "content": str(e.response.content),
+                    },
+                )
             raise
 
-    def auth_params(self, state=None, *args, **kwargs):
+    def auth_params(
+        self, state: Optional[str] = None, *args: Any, **kwargs: Any
+    ) -> Dict[str, Any]:
         """
         Apple requires to set `response_mode` to `form_post` if `scope`
         parameter is passed.
         """
-        log.info("Generating auth params")
+        log.info("Generating auth parameters")
         params = super().auth_params(state=state, *args, **kwargs)
 
         if self.RESPONSE_MODE:
@@ -159,9 +171,8 @@ class IBLAppleIdAuth(AppleIdAuth):
 
         # Store state in both cache and session
         if state:
-            # Only show first 8 chars of state
             state_preview = f"{state[:8]}..." if state else None
-            log.info(f"Storing state in auth_params: {state_preview}")
+            log.info("Storing auth state", extra={"state_preview": state_preview})
             try:
                 session_key = self.strategy.session.session_key
                 if not session_key:
@@ -172,28 +183,35 @@ class IBLAppleIdAuth(AppleIdAuth):
                 cache.set(cache_key, state, timeout=300)
                 self.strategy.session["apple_auth_state"] = state
 
-                # Verify storage (using masked state value)
+                # Verify storage
                 stored_cache_state = cache.get(cache_key)
                 stored_session_state = self.strategy.session.get("apple_auth_state")
-                log.info(f"State stored in cache: {state_preview}")
-                log.info(f"State stored in session: {state_preview}")
+                log.debug(
+                    "State storage verification",
+                    extra={
+                        "cache_state_exists": bool(stored_cache_state),
+                        "session_state_exists": bool(stored_session_state),
+                    },
+                )
             except Exception as e:
                 log.error(
-                    f"Error storing state in auth_params: {str(e)}", exc_info=True
+                    "Failed to store auth state",
+                    extra={"error_type": type(e).__name__, "error_message": str(e)},
                 )
 
-        log.debug(f"Auth params: {params}")
+        log.debug(
+            "Generated auth parameters", extra={"params_keys": list(params.keys())}
+        )
         return params
 
-    def get_private_key(self):
-        """
-        Return contents of the private key file. Override this method to provide
-        secret key from another source if needed.
-        """
+    def get_private_key(self) -> str:
+        """Return contents of the private key file."""
+        log.debug("Retrieving private key")
         return self.setting("SECRET")
 
-    def generate_client_secret(self):
+    def generate_client_secret(self) -> str:
         """Generate a client secret for Apple ID authentication."""
+        log.info("Generating client secret")
         now = int(time.time())
         client_id = self.setting("CLIENT")
         team_id = self.setting("TEAM")
@@ -203,9 +221,6 @@ class IBLAppleIdAuth(AppleIdAuth):
             else ""
         )
         private_key = self.get_private_key()
-
-        log.info("Generating client secret for Apple ID authentication")
-        # Removed logging of sensitive data (client_id, team_id, key_id)
 
         headers = {"kid": key_id}
         payload = {
@@ -223,320 +238,247 @@ class IBLAppleIdAuth(AppleIdAuth):
             log.info("Client secret generated successfully")
             return token
         except Exception as e:
-            log.error("Failed to generate client secret")
+            log.error(
+                "Failed to generate client secret",
+                extra={"error_type": type(e).__name__, "error_message": str(e)},
+            )
             raise
 
-    def get_apple_jwk(self, kid=None):
-        """
-        Return requested Apple public key or all available.
-        """
+    def get_apple_jwk(self, kid: Optional[str] = None) -> Union[str, List[str]]:
+        """Return requested Apple public key or all available."""
+        log.info("Retrieving Apple JWK", extra={"kid": kid})
         keys = self.get_json(url=self.JWK_URL).get("keys")
 
         if not isinstance(keys, list) or not keys:
+            log.error("Invalid JWK response", extra={"keys_type": type(keys)})
             raise AuthFailed(self, "Invalid jwk response")
 
         if kid:
-            return json.dumps([key for key in keys if key["kid"] == kid][0])
+            matching_keys = [key for key in keys if key["kid"] == kid]
+            if not matching_keys:
+                log.error("No matching JWK found", extra={"kid": kid})
+                raise AuthFailed(self, f"No matching key found for kid: {kid}")
+            return json.dumps(matching_keys[0])
         else:
             return (json.dumps(key) for key in keys)
 
-    def decode_id_token(self, id_token):
-        """
-        Decode and validate JWT token from apple and return payload including
-        user data.
-        """
+    def decode_id_token(self, id_token: str) -> Dict[str, Any]:
+        """Decode and validate JWT token from apple and return payload."""
+        log.info("Decoding ID token")
         if not id_token:
+            log.error("Missing ID token")
             raise AuthFailed(self, "Missing id_token parameter")
 
         try:
-            kid = jwt.get_unverified_header(id_token).get("kid")
-            log.info(f"Decoding id_token with kid: {kid}")
-            public_key = RSAAlgorithm.from_jwk(self.get_apple_jwk(kid))
-            decoded = jwt.decode(
+            header = jwt.get_unverified_header(id_token)
+            log.debug("Retrieved token header", extra={"header": header})
+
+            if "kid" not in header:
+                log.error("Missing kid in token header")
+                raise AuthFailed(self, "Invalid id_token header (missing kid)")
+
+            apple_jwk = self.get_apple_jwk(header["kid"])
+            key = RSAAlgorithm.from_jwk(apple_jwk)
+
+            audience = self.setting("AUDIENCE", [self.setting("CLIENT")])
+            if not isinstance(audience, list):
+                audience = [audience]
+
+            log.debug("Decoding token with audience", extra={"audience": audience})
+
+            return jwt.decode(
                 id_token,
-                key=public_key,
-                audience=self.get_audience(),
+                key=key,
+                audience=audience,
                 algorithms=["RS256"],
             )
-            log.info("id_token decoded successfully")
-            return decoded
         except PyJWTError as e:
-            log.error(f"Token validation failed: {str(e)}")
-            raise AuthFailed(self, "Token validation failed")
+            log.error(
+                "Failed to decode ID token",
+                extra={"error_type": type(e).__name__, "error_message": str(e)},
+            )
+            raise AuthFailed(self, str(e))
 
-    def get_user_fullname(self, email):
-        log.info(f"Checking user detail for email: {email}")
+    def get_user_fullname(self, email: str) -> Dict[str, str]:
+        """Get user's full name from email."""
+        log.info("Retrieving user full name", extra={"email": email})
         try:
-            # Check if the user exists
             user = User.objects.get(email=email)
-            # If exists, return first name and last name
-            log.info(
-                f"User detail found for email: {email}, using: {user.first_name} {user.last_name}"
+            log.debug(
+                "Found user for full name",
+                extra={
+                    "email": email,
+                    "first_name": user.first_name,
+                    "last_name": user.last_name,
+                },
             )
-            return user.first_name, user.last_name
+            return {
+                "first_name": user.first_name,
+                "last_name": user.last_name,
+            }
         except ObjectDoesNotExist:
-            # User does not exist
-            log.info(f"No user detail found for email: {email}")
-            return "", ""
+            log.info("No user found for full name", extra={"email": email})
+            return {"first_name": "", "last_name": ""}
 
-    def get_user_by_social_uid(self, uid, provider="apple-id"):
-        """
-        Fetch the Open edX user associated with a given social auth UID.
-
-        Args:
-            provider (str): The name of the social authentication provider (e.g., 'apple', 'google-oauth2').
-            uid (str): The UID provided by the social auth provider.
-
-        Returns:
-            dict: A dictionary with user details if found, otherwise None.
-        """
-        log.info(f"Checking user detail for apple_id: {uid}")
-        try:
-            # Get the social auth entry
-            social_auth = UserSocialAuth.objects.get(provider=provider, uid=uid)
-
-            # Retrieve the associated user
-            user = social_auth.user
-
-            # Prepare user details to return
-            return user.first_name, user.last_name
-
-        except UserSocialAuth.DoesNotExist:
-            log.info(f"No user detail found for apple_id: {uid}")
-            return "", ""
-
-    def get_user_details(self, response):
-        """Get user details from the response."""
-        name = response.get("name") or {}
-        email = response.get("email", "")
-        if not email:
-            log.error("No email provided in Apple ID response")
-
-        # Log successful user detail retrieval without exposing data
-        log.info("Retrieved user details from Apple ID response")
-        if email:
-            log.info("Email address present in response")
-        apple_id = response.get(self.ID_KEY, "")
-
-        # Check if user creation is disabled and if the user exists
-        if getattr(settings, "SOCIAL_AUTH_DISABLE_USER_CREATION", False):
-            # Check if user exists by email
-            user_exists = User.objects.filter(email=email).exists() if email else False
-            # Check if user exists by username (using email or apple_id based on settings)
-            username = email if self.setting("EMAIL_AS_USERNAME") else apple_id
-            username_exists = (
-                User.objects.filter(username=username).exists() if username else False
-            )
-            # Check if user exists by social auth
-            social_auth_exists = (
-                UserSocialAuth.objects.filter(provider=self.name, uid=apple_id).exists()
-                if apple_id
-                else False
-            )
-
-            if not user_exists and not username_exists and not social_auth_exists:
-                log.error(
-                    f"User creation disabled and no existing user found for Apple ID login. "
-                    f"Checked email, username and social auth."
-                )
-                raise PermissionDenied(
-                    "User creation is disabled. Please contact support if you need access."
-                )
-
-            log.info("Found existing user match for Apple ID login")
-
-        # Add call to check if user detail exists
-        log.info(f"Checking user detail for email: {email}")
-        get_first_name, get_last_name = self.get_user_fullname(email)
-
-        if not get_first_name and not get_last_name:
-            log.info(
-                f"No user detail found for email: {email}, checking by apple_id: {apple_id}"
-            )
-            get_first_name, get_last_name = self.get_user_by_social_uid(apple_id)
-
-        get_fullname = ""
-        if get_first_name or get_last_name:
-            log.info(
-                f"User detail found for email: {email}, using: {get_first_name} {get_last_name}"
-            )
-            get_fullname = f"{get_first_name} {get_last_name}".strip()
-
-        # Rest of the method remains the same
-        fullname, first_name, last_name = self.get_user_names(
-            fullname=get_fullname or str(email).split("@")[0],
-            first_name=name.get("firstName", get_first_name),
-            last_name=name.get("lastName", get_last_name),
+    def get_user_by_social_uid(
+        self, uid: str, provider: str = "apple-id"
+    ) -> Optional[User]:
+        """Get user by social auth UID."""
+        log.info(
+            "Retrieving user by social UID", extra={"uid": uid, "provider": provider}
         )
+        try:
+            social_auth = UserSocialAuth.objects.get(provider=provider, uid=uid)
+            log.debug(
+                "Found user by social UID",
+                extra={
+                    "uid": uid,
+                    "provider": provider,
+                    "user_id": social_auth.user.id,
+                },
+            )
+            return social_auth.user
+        except ObjectDoesNotExist:
+            log.info(
+                "No user found for social UID", extra={"uid": uid, "provider": provider}
+            )
+            return None
+
+    def get_user_details(self, response: Dict[str, Any]) -> Dict[str, str]:
+        """Return user details from Apple ID response."""
+        log.info("Processing user details from Apple ID response")
+        if not response.get("email"):
+            log.error("Missing email in Apple ID response")
+            raise AuthFailed(self, "Email is required for authentication")
+
+        email = response.get("email", "")
+        log.debug("Extracted email from response", extra={"email": email})
+
+        # Get user details from existing user if available
+        try:
+            user = User.objects.get(email=email)
+            log.info("Found existing user", extra={"email": email})
+            first_name = user.first_name
+            last_name = user.last_name
+        except ObjectDoesNotExist:
+            log.info("No existing user found", extra={"email": email})
+            first_name = ""
+            last_name = ""
 
         user_details = {
-            "fullname": fullname or str(email).split("@")[0],
-            "first_name": first_name or str(email).split("@")[0],
-            "last_name": last_name or str(email).split("@")[0],
+            "username": email.split("@", 1)[0],
             "email": email,
+            "first_name": first_name,
+            "last_name": last_name,
         }
-        if email and self.setting("EMAIL_AS_USERNAME"):
-            user_details["username"] = email
-        if apple_id and not self.setting("EMAIL_AS_USERNAME"):
-            user_details["username"] = apple_id
-
+        log.debug("Final user details", extra={"user_details": user_details})
         return user_details
 
-    def get_and_store_state(self, request):
-        """Generate and store state parameter."""
-        log.info("Generating and storing state parameter")
-
+    def get_and_store_state(self, request: Any) -> str:
+        """Get and store state for Apple ID authentication."""
+        log.info("Getting and storing state")
         state = str(uuid.uuid4())
         session_key = request.session.session_key
         if not session_key:
             request.session.create()
             session_key = request.session.session_key
 
-        log.info(f"Generated state: {state}")
+        cache_key = f"apple_auth_state:{session_key}"
+        cache.set(cache_key, state, timeout=300)
+        request.session["apple_auth_state"] = state
 
-        try:
-            if not verify_redis_cache():
-                log.warning("Falling back to session-only storage")
-                request.session["apple_auth_state"] = state
-                return state
+        log.debug(
+            "State stored",
+            extra={"state_preview": f"{state[:8]}...", "session_key": session_key},
+        )
+        return state
 
-            # Store state using Django's cache framework
-            cache_key = f"apple_auth_state:{session_key}"
-            cache.set(cache_key, state, timeout=300)  # 5 minutes timeout
+    def validate_state(self) -> None:
+        """Validate state for Apple ID authentication."""
+        log.info("Validating state")
+        state = self.strategy.session.get("apple_auth_state")
+        if not state:
+            log.error("Missing state in session")
+            raise AuthStateMissing(self)
 
-            # Also store in session for redundancy
-            request.session["apple_auth_state"] = state
+        session_key = self.strategy.session.session_key
+        cache_key = f"apple_auth_state:{session_key}"
+        cached_state = cache.get(cache_key)
 
-            # Verify storage
-            stored_cache_state = cache.get(cache_key)
-            stored_session_state = request.session.get("apple_auth_state")
+        if not cached_state:
+            log.error("Missing state in cache")
+            raise AuthStateMissing(self)
 
-            log.info(f"State stored in cache: {stored_cache_state}")
-            log.info(f"State stored in session: {stored_session_state}")
+        if state != cached_state:
+            log.error(
+                "State mismatch",
+                extra={
+                    "session_state": f"{state[:8]}...",
+                    "cache_state": f"{cached_state[:8]}...",
+                },
+            )
+            raise AuthStateMissing(self)
 
-            return state
-
-        except Exception as e:
-            log.error(f"Error storing state: {str(e)}", exc_info=True)
-            # Fallback to session-only storage
-            request.session["apple_auth_state"] = state
-            return state
-
-    def validate_state(self):
-        """Validate the state parameter."""
-        try:
-            log.info("Validating state")
-            received_state = self.get_request_state()
-            session_key = self.strategy.session.session_key
-
-            # Only log partial state for debugging
-            state_preview = received_state[:8] if received_state else None
-            log.info(f"Validating state starting with: {state_preview}...")
-
-            # Check if we're using Redis cache
-            using_redis = verify_redis_cache()
-
-            if using_redis:
-                # Try getting state from cache
-                cache_key = f"apple_auth_state:{session_key}"
-                stored_cache_state = cache.get(cache_key)
-                if stored_cache_state and stored_cache_state == received_state:
-                    log.info("State validated from cache")
-                    cache.delete(cache_key)
-                    return received_state
-
-            # Try session storage
-            stored_session_state = self.strategy.session.get("apple_auth_state")
-            if stored_session_state and stored_session_state == received_state:
-                log.info("State validated from session")
-                del self.strategy.session["apple_auth_state"]
-                return received_state
-
-            if not using_redis and not stored_session_state:
-                log.warning("No stored state found (session only)")
-            elif using_redis and not stored_cache_state and not stored_session_state:
-                log.warning("No stored state found (cache and session)")
-
-            if (
-                hasattr(settings, "SOCIAL_AUTH_APPLE_ID_SKIP_STATE_VALIDATION")
-                and settings.SOCIAL_AUTH_APPLE_ID_SKIP_STATE_VALIDATION
-            ):
-                log.warning("State validation bypassed per settings")
-                return received_state
-
-            log.info("State validated successfully")
-            return received_state
-
-        except Exception as e:
-            log.error("State validation failed")
-            raise
+        log.debug("State validation successful")
 
     @classmethod
-    def verify_patch(cls):
-        """Verify that this class is being used as the AppleIdAuth."""
-        from common.djangoapps.third_party_auth import appleid
-
-        current_class = appleid.AppleIdAuth
-        log.info(f"Current AppleIdAuth class: {current_class}")
-        return current_class == cls
-
-    def request_access_token(self, *args, **kwargs):
-        """Request the access token from Apple."""
+    def verify_patch(cls) -> None:
+        """Verify that the patch is applied correctly."""
+        log.info("Verifying Apple ID patch")
         try:
-            log.info("Requesting access token from Apple")
+            from social_core.backends import apple
+
+            if apple.AppleIdAuth != cls:
+                log.error("Apple ID patch verification failed")
+                raise RuntimeError("Apple ID patch verification failed")
+            log.info("Apple ID patch verified successfully")
+        except Exception as e:
+            log.error(
+                "Apple ID patch verification error",
+                extra={"error_type": type(e).__name__, "error_message": str(e)},
+            )
+            raise
+
+    def request_access_token(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        """Request access token from Apple ID."""
+        log.info("Requesting access token")
+        try:
             response = super().request_access_token(*args, **kwargs)
-            log.info("Access token received successfully")
+            log.info("Access token request successful")
             return response
         except Exception as e:
-            log.error("Failed to get access token")
-            raise
-
-    def get_json(self, *args, **kwargs):
-        """Override get_json to add logging."""
-        try:
-            log.info(
-                f"IBLAppleIdAuth.get_json called with url: {kwargs.get('url', args[0] if args else 'No URL')}"
+            log.error(
+                "Access token request failed",
+                extra={"error_type": type(e).__name__, "error_message": str(e)},
             )
-            log.debug(f"get_json args: {args}")
-            log.debug(f"get_json kwargs: {kwargs}")
-            return super().get_json(*args, **kwargs)
+            raise
+
+    def get_json(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        """Get JSON response from Apple ID."""
+        log.info("Requesting JSON from Apple ID")
+        try:
+            response = super().get_json(*args, **kwargs)
+            log.info("JSON request successful")
+            return response
         except Exception as e:
-            log.error(f"get_json failed: {str(e)}")
+            log.error(
+                "JSON request failed",
+                extra={"error_type": type(e).__name__, "error_message": str(e)},
+            )
             raise
 
 
-def patch():
+def patch() -> None:
     """Patch the AppleIdAuth class with our implementation."""
-    log.info("Applying IBLAppleIdAuth patch...")
+    log.info("Starting Apple ID patch application")
     try:
-        # Patch all possible import locations
-        from common.djangoapps.third_party_auth import appleid
         from social_core.backends import apple
 
-        log.info(f"Current AppleIdAuth class: {appleid.AppleIdAuth}")
-        log.info(f"Current social_core AppleIdAuth class: {apple.AppleIdAuth}")
+        log.debug("Current AppleIdAuth class", extra={"class": str(apple.AppleIdAuth)})
 
-        # Patch both locations
-        appleid.AppleIdAuth = IBLAppleIdAuth
         apple.AppleIdAuth = IBLAppleIdAuth
-
-        # Verify patches
-        log.info(f"After patching appleid.AppleIdAuth: {appleid.AppleIdAuth}")
-        log.info(f"After patching apple.AppleIdAuth: {apple.AppleIdAuth}")
-
-        # Add a hook to the request_access_token method to ensure our patch is used
-        from social_core.backends.oauth import BaseOAuth2
-
-        original_request_access_token = BaseOAuth2.request_access_token
-
-        def patched_request_access_token(self, *args, **kwargs):
-            if isinstance(self, IBLAppleIdAuth):
-                log.info(f"request_access_token called on {self.__class__}")
-                log.info("Using IBLAppleIdAuth implementation")
-            return original_request_access_token(self, *args, **kwargs)
-
-        BaseOAuth2.request_access_token = patched_request_access_token
+        log.info("Successfully patched AppleIdAuth class")
 
     except Exception as e:
-        log.error(f"Error during patching: {str(e)}", exc_info=True)
+        log.exception("Failed to apply Apple ID patch", extra={"error": str(e)})
         raise

--- a/src/ibl_third_party_auth/patches/patch_azuread.py
+++ b/src/ibl_third_party_auth/patches/patch_azuread.py
@@ -9,6 +9,7 @@ Additional changes:
 """
 
 import logging
+from typing import Any, Dict, Optional
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -27,9 +28,10 @@ class IBLAzureADOAuth2(AzureADOAuth2):
     - User existence checks
     """
 
-    def get_user_details(self, response):
+    def get_user_details(self, response: Dict[str, Any]) -> Dict[str, str]:
         """Return user details from Azure AD account."""
-        log.info("Getting user details from Azure AD response")
+        log.info("Processing Azure AD response")
+        log.debug("Response keys", extra={"keys": list(response.keys())})
 
         # Get email from the preferred_username which is usually the email
         email = response.get("preferred_username", "")
@@ -37,7 +39,10 @@ class IBLAzureADOAuth2(AzureADOAuth2):
             email = response.get("email")
 
         if not email:
-            log.error("No email provided in Azure AD response")
+            log.error("Missing email in Azure AD response")
+            raise PermissionDenied("Email is required for authentication")
+
+        log.debug("Extracted email", extra={"email": email})
 
         # Get name details from response
         name, given_name, family_name = (
@@ -48,83 +53,111 @@ class IBLAzureADOAuth2(AzureADOAuth2):
         fullname, first_name, last_name = self.get_user_names(
             name, given_name, family_name
         )
+        log.debug(
+            "Extracted name details",
+            extra={
+                "name": name,
+                "given_name": given_name,
+                "family_name": family_name,
+                "fullname": fullname,
+                "first_name": first_name,
+                "last_name": last_name,
+            },
+        )
 
         # Check if user creation is disabled and if the user exists
         if getattr(settings, "SOCIAL_AUTH_DISABLE_USER_CREATION", False):
+            log.info("User creation is disabled - checking for existing user")
+
             # Check if user exists by email
             user_exists = User.objects.filter(email=email).exists() if email else False
+            log.debug("User existence check by email", extra={"exists": user_exists})
 
             # Check if user exists by username (using email)
             username = email.split("@", 1)[0] if email else ""
             username_exists = (
                 User.objects.filter(username=username).exists() if username else False
             )
+            log.debug(
+                "User existence check by username",
+                extra={"username": username, "exists": username_exists},
+            )
 
             # Check if user exists by social auth
-            # Azure AD's unique user ID is in the 'oid' field
             azure_id = response.get("oid", "")
             social_auth_exists = (
                 UserSocialAuth.objects.filter(provider=self.name, uid=azure_id).exists()
                 if azure_id
                 else False
             )
+            log.debug(
+                "User existence check by social auth",
+                extra={"azure_id": azure_id, "exists": social_auth_exists},
+            )
 
-            if not user_exists and not username_exists and not social_auth_exists:
+            if not (user_exists or username_exists or social_auth_exists):
                 log.error(
-                    f"User creation disabled and no existing user found for Azure AD login. "
-                    f"Checked email, username and social auth."
+                    "User creation disabled and no existing user found",
+                    extra={
+                        "email": email,
+                        "username": username,
+                        "azure_id": azure_id,
+                        "user_exists": user_exists,
+                        "username_exists": username_exists,
+                        "social_auth_exists": social_auth_exists,
+                    },
                 )
                 raise PermissionDenied(
                     "User creation is disabled. Please contact support if you need access."
                 )
 
-            log.info("Found existing user match for Azure AD login")
+            log.info("Found existing user match", extra={"email": email})
 
         # Get user details from existing user if available
         try:
             user = User.objects.get(email=email)
-            log.info(f"Found existing user details for email: {email}")
+            log.info("Found existing user", extra={"email": email})
             first_name = first_name or user.first_name
             last_name = last_name or user.last_name
         except User.DoesNotExist:
-            log.info(f"No existing user found for email: {email}")
-            pass
+            log.info("No existing user found", extra={"email": email})
 
         user_details = {
-            "username": email.split("@", 1)[0],  # Match default implementation
+            "username": email.split("@", 1)[0],
             "email": email,
             "fullname": fullname,
             "first_name": first_name,
             "last_name": last_name,
         }
-
-        log.info("Successfully processed user details from Azure AD")
+        log.debug("Final user details", extra={"user_details": user_details})
         return user_details
 
-    def get_user_id(self, details, response):
+    def get_user_id(self, details: Dict[str, str], response: Dict[str, Any]) -> str:
         """Use Azure AD's 'oid' as unique id."""
         if self.setting("USE_UNIQUE_USER_ID", False):
-            log.info("Using Azure AD oid as unique user ID")
+            log.debug(
+                "Using Azure AD oid as unique user ID",
+                extra={"oid": response.get("oid")},
+            )
             return response.get("oid")
 
-        log.info("Using email as user ID")
+        log.debug("Using email as user ID", extra={"email": details.get("email")})
         return details.get("email")
 
 
-def patch():
+def patch() -> None:
     """Patch the AzureADOAuth2 class with our implementation."""
-    log.info("Applying IBLAzureADOAuth2 patch...")
+    log.info("Starting Azure AD patch application")
     try:
-        # Patch all possible import locations
         from social_core.backends import azuread
 
-        log.info(f"Current AzureADOAuth2 class: {azuread.AzureADOAuth2}")
+        log.debug(
+            "Current AzureADOAuth2 class", extra={"class": str(azuread.AzureADOAuth2)}
+        )
 
-        # Patch the class
         azuread.AzureADOAuth2 = IBLAzureADOAuth2
-
-        log.info(f"After patching AzureADOAuth2: {azuread.AzureADOAuth2}")
+        log.info("Successfully patched AzureADOAuth2 class")
 
     except Exception as e:
-        log.error(f"Error during patching: {str(e)}", exc_info=True)
+        log.exception("Failed to apply Azure AD patch", extra={"error": str(e)})
         raise

--- a/src/ibl_third_party_auth/patches/patch_azuread.py
+++ b/src/ibl_third_party_auth/patches/patch_azuread.py
@@ -1,0 +1,130 @@
+"""
+Vendored from social-core:
+https://github.com/python-social-auth/social-core/blob/master/social_core/backends/azuread.py
+
+Additional changes:
+- Added support for SOCIAL_AUTH_DISABLE_USER_CREATION setting
+- Added enhanced logging
+- Added user existence checks before creation
+"""
+
+import logging
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.exceptions import PermissionDenied
+from social_core.backends.azuread import AzureADOAuth2
+from social_django.models import UserSocialAuth
+
+log = logging.getLogger(__name__)
+
+
+class IBLAzureADOAuth2(AzureADOAuth2):
+    """
+    Azure AD OAuth2 authentication backend with additional features:
+    - Respects SOCIAL_AUTH_DISABLE_USER_CREATION setting
+    - Enhanced logging
+    - User existence checks
+    """
+
+    def get_user_details(self, response):
+        """Return user details from Azure AD account."""
+        log.info("Getting user details from Azure AD response")
+
+        # Get email from the preferred_username which is usually the email
+        email = response.get("preferred_username", "")
+        if not email and response.get("email"):
+            email = response.get("email")
+
+        if not email:
+            log.error("No email provided in Azure AD response")
+
+        # Get name details from response
+        name, given_name, family_name = (
+            response.get("name", ""),
+            response.get("given_name", ""),
+            response.get("family_name", ""),
+        )
+        fullname, first_name, last_name = self.get_user_names(
+            name, given_name, family_name
+        )
+
+        # Check if user creation is disabled and if the user exists
+        if getattr(settings, "SOCIAL_AUTH_DISABLE_USER_CREATION", False):
+            # Check if user exists by email
+            user_exists = User.objects.filter(email=email).exists() if email else False
+
+            # Check if user exists by username (using email)
+            username = email.split("@", 1)[0] if email else ""
+            username_exists = (
+                User.objects.filter(username=username).exists() if username else False
+            )
+
+            # Check if user exists by social auth
+            # Azure AD's unique user ID is in the 'oid' field
+            azure_id = response.get("oid", "")
+            social_auth_exists = (
+                UserSocialAuth.objects.filter(provider=self.name, uid=azure_id).exists()
+                if azure_id
+                else False
+            )
+
+            if not user_exists and not username_exists and not social_auth_exists:
+                log.error(
+                    f"User creation disabled and no existing user found for Azure AD login. "
+                    f"Checked email, username and social auth."
+                )
+                raise PermissionDenied(
+                    "User creation is disabled. Please contact support if you need access."
+                )
+
+            log.info("Found existing user match for Azure AD login")
+
+        # Get user details from existing user if available
+        try:
+            user = User.objects.get(email=email)
+            log.info(f"Found existing user details for email: {email}")
+            first_name = first_name or user.first_name
+            last_name = last_name or user.last_name
+        except User.DoesNotExist:
+            log.info(f"No existing user found for email: {email}")
+            pass
+
+        user_details = {
+            "username": email.split("@", 1)[0],  # Match default implementation
+            "email": email,
+            "fullname": fullname,
+            "first_name": first_name,
+            "last_name": last_name,
+        }
+
+        log.info("Successfully processed user details from Azure AD")
+        return user_details
+
+    def get_user_id(self, details, response):
+        """Use Azure AD's 'oid' as unique id."""
+        if self.setting("USE_UNIQUE_USER_ID", False):
+            log.info("Using Azure AD oid as unique user ID")
+            return response.get("oid")
+
+        log.info("Using email as user ID")
+        return details.get("email")
+
+
+def patch():
+    """Patch the AzureADOAuth2 class with our implementation."""
+    log.info("Applying IBLAzureADOAuth2 patch...")
+    try:
+        # Patch all possible import locations
+        from social_core.backends import azuread
+
+        log.info(f"Current AzureADOAuth2 class: {azuread.AzureADOAuth2}")
+
+        # Patch the class
+        azuread.AzureADOAuth2 = IBLAzureADOAuth2
+
+        log.info(f"After patching AzureADOAuth2: {azuread.AzureADOAuth2}")
+
+    except Exception as e:
+        log.error(f"Error during patching: {str(e)}", exc_info=True)
+        raise

--- a/src/ibl_third_party_auth/patches/patch_google.py
+++ b/src/ibl_third_party_auth/patches/patch_google.py
@@ -9,6 +9,7 @@ Additional changes:
 """
 
 import logging
+from typing import Any, Dict, Optional
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -27,32 +28,44 @@ class IBLGoogleOAuth2(GoogleOAuth2):
     - User existence checks
     """
 
-    def get_user_details(self, response):
+    def get_user_details(self, response: Dict[str, Any]) -> Dict[str, str]:
         """Return user details from Google API account."""
-        log.info("Getting user details from Google response")
+        log.debug(
+            "Processing Google OAuth2 response",
+            extra={"response_keys": list(response.keys())},
+        )
 
         if not response.get("email"):
-            log.error("No email provided in Google response")
+            log.error("Authentication failed: No email in Google response")
             raise PermissionDenied("Email is required for authentication")
 
         # Get basic details from response
         email = response.get("email", "")
+        log.debug("Extracted email from response", extra={"email": email})
 
-        # Check if user creation is disabled and if the user exists - do this BEFORE processing other details
+        # Check if user creation is disabled and if the user exists
         if getattr(settings, "SOCIAL_AUTH_DISABLE_USER_CREATION", False):
-            log.info("SOCIAL_AUTH_DISABLE_USER_CREATION setting is: True")
+            log.info(
+                "User creation is disabled - checking for existing user",
+                extra={"email": email},
+            )
 
             # Check if user exists by email
             user_exists = User.objects.filter(email=email).exists() if email else False
+            log.debug("User existence check by email", extra={"exists": user_exists})
 
             # Check if user exists by username (using email)
             username = email.split("@", 1)[0] if email else ""
             username_exists = (
                 User.objects.filter(username=username).exists() if username else False
             )
+            log.debug(
+                "User existence check by username",
+                extra={"username": username, "exists": username_exists},
+            )
 
             # Check if user exists by social auth
-            google_id = response.get("sub", "")  # Google's unique user ID
+            google_id = response.get("sub", "")
             social_auth_exists = (
                 UserSocialAuth.objects.filter(
                     provider=self.name, uid=google_id
@@ -60,19 +73,30 @@ class IBLGoogleOAuth2(GoogleOAuth2):
                 if google_id
                 else False
             )
+            log.debug(
+                "User existence check by social auth",
+                extra={"google_id": google_id, "exists": social_auth_exists},
+            )
 
             if not (user_exists or username_exists or social_auth_exists):
                 log.error(
-                    f"User creation disabled and no existing user found for Google login. "
-                    f"Email: {email}, Username: {username}, Google ID: {google_id}"
+                    "User creation disabled and no existing user found",
+                    extra={
+                        "email": email,
+                        "username": username,
+                        "google_id": google_id,
+                        "user_exists": user_exists,
+                        "username_exists": username_exists,
+                        "social_auth_exists": social_auth_exists,
+                    },
                 )
                 raise PermissionDenied(
                     "User creation is disabled. Please contact support if you need access."
                 )
 
-            log.info(f"Found existing user match for Google login - Email: {email}")
+            log.info("Found existing user match", extra={"email": email})
 
-        # Only proceed with additional details if we haven't raised an exception
+        # Get user details from response
         name, given_name, family_name = (
             response.get("name", ""),
             response.get("given_name", ""),
@@ -81,57 +105,67 @@ class IBLGoogleOAuth2(GoogleOAuth2):
         fullname, first_name, last_name = self.get_user_names(
             name, given_name, family_name
         )
+        log.debug(
+            "Extracted user details",
+            extra={
+                "name": name,
+                "given_name": given_name,
+                "family_name": family_name,
+                "fullname": fullname,
+                "first_name": first_name,
+                "last_name": last_name,
+            },
+        )
 
         # Get user details from existing user if available
         try:
             user = User.objects.get(email=email)
-            log.info(f"Found existing user details for email: {email}")
+            log.info("Found existing user", extra={"email": email})
             first_name = first_name or user.first_name
             last_name = last_name or user.last_name
         except User.DoesNotExist:
-            log.info(f"No existing user found for email: {email}")
-            # If we get here and user creation is disabled, something went wrong
+            log.info("No existing user found", extra={"email": email})
             if getattr(settings, "SOCIAL_AUTH_DISABLE_USER_CREATION", False):
-                log.error("Critical: User existence check inconsistency")
+                log.error("User existence check inconsistency", extra={"email": email})
                 raise PermissionDenied(
                     "An error occurred during authentication. Please contact support."
                 )
 
         user_details = {
-            "username": email.split("@", 1)[0],  # Match default Google implementation
+            "username": email.split("@", 1)[0],
             "email": email,
             "fullname": fullname,
             "first_name": first_name,
             "last_name": last_name,
         }
-
-        log.info("Successfully processed user details from Google")
+        log.debug("Final user details", extra={"user_details": user_details})
         return user_details
 
-    def get_user_id(self, details, response):
+    def get_user_id(self, details: Dict[str, str], response: Dict[str, Any]) -> str:
         """Use google 'sub' as unique id."""
         if self.setting("USE_UNIQUE_USER_ID", False):
-            log.info("Using Google sub as unique user ID")
+            log.debug(
+                "Using Google sub as unique user ID", extra={"sub": response.get("sub")}
+            )
             return response.get("sub")
 
-        log.info("Using email as user ID")
+        log.debug("Using email as user ID", extra={"email": details.get("email")})
         return details.get("email")
 
 
 def patch():
     """Patch the GoogleOAuth2 class with our implementation."""
-    log.info("Applying IBLGoogleOAuth2 patch...")
+    log.info("Starting Google OAuth2 patch application")
     try:
-        # Patch all possible import locations
         from social_core.backends import google
 
-        log.info(f"Current GoogleOAuth2 class: {google.GoogleOAuth2}")
+        log.debug(
+            "Current GoogleOAuth2 class", extra={"class": str(google.GoogleOAuth2)}
+        )
 
-        # Patch the class
         google.GoogleOAuth2 = IBLGoogleOAuth2
-
-        log.info(f"After patching GoogleOAuth2: {google.GoogleOAuth2}")
+        log.info("Successfully patched GoogleOAuth2 class")
 
     except Exception as e:
-        log.error(f"Error during patching: {str(e)}", exc_info=True)
+        log.exception("Failed to apply Google OAuth2 patch", extra={"error": str(e)})
         raise

--- a/src/ibl_third_party_auth/patches/patch_google.py
+++ b/src/ibl_third_party_auth/patches/patch_google.py
@@ -1,0 +1,127 @@
+"""
+Vendored from social-core:
+https://github.com/python-social-auth/social-core/blob/master/social_core/backends/google.py
+
+Additional changes:
+- Added support for SOCIAL_AUTH_DISABLE_USER_CREATION setting
+- Added enhanced logging
+- Added user existence checks before creation
+"""
+
+import logging
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.exceptions import PermissionDenied
+from social_core.backends.google import GoogleOAuth2
+from social_django.models import UserSocialAuth
+
+log = logging.getLogger(__name__)
+
+
+class IBLGoogleOAuth2(GoogleOAuth2):
+    """
+    Google OAuth2 authentication backend with additional features:
+    - Respects SOCIAL_AUTH_DISABLE_USER_CREATION setting
+    - Enhanced logging
+    - User existence checks
+    """
+
+    def get_user_details(self, response):
+        """Return user details from Google API account."""
+        log.info("Getting user details from Google response")
+
+        if not response.get("email"):
+            log.error("No email provided in Google response")
+
+        # Get basic details from response
+        email = response.get("email", "")
+        name, given_name, family_name = (
+            response.get("name", ""),
+            response.get("given_name", ""),
+            response.get("family_name", ""),
+        )
+        fullname, first_name, last_name = self.get_user_names(
+            name, given_name, family_name
+        )
+
+        # Check if user creation is disabled and if the user exists
+        if getattr(settings, "SOCIAL_AUTH_DISABLE_USER_CREATION", False):
+            # Check if user exists by email
+            user_exists = User.objects.filter(email=email).exists() if email else False
+
+            # Check if user exists by username (using email)
+            username = email.split("@", 1)[0] if email else ""
+            username_exists = (
+                User.objects.filter(username=username).exists() if username else False
+            )
+
+            # Check if user exists by social auth
+            google_id = response.get("sub", "")  # Google's unique user ID
+            social_auth_exists = (
+                UserSocialAuth.objects.filter(
+                    provider=self.name, uid=google_id
+                ).exists()
+                if google_id
+                else False
+            )
+
+            if not user_exists and not username_exists and not social_auth_exists:
+                log.error(
+                    f"User creation disabled and no existing user found for Google login. "
+                    f"Checked email, username and social auth."
+                )
+                raise PermissionDenied(
+                    "User creation is disabled. Please contact support if you need access."
+                )
+
+            log.info("Found existing user match for Google login")
+
+        # Get user details from existing user if available
+        try:
+            user = User.objects.get(email=email)
+            log.info(f"Found existing user details for email: {email}")
+            first_name = first_name or user.first_name
+            last_name = last_name or user.last_name
+        except User.DoesNotExist:
+            log.info(f"No existing user found for email: {email}")
+            pass
+
+        user_details = {
+            "username": email.split("@", 1)[0],  # Match default Google implementation
+            "email": email,
+            "fullname": fullname,
+            "first_name": first_name,
+            "last_name": last_name,
+        }
+
+        log.info("Successfully processed user details from Google")
+        return user_details
+
+    def get_user_id(self, details, response):
+        """Use google 'sub' as unique id."""
+        if self.setting("USE_UNIQUE_USER_ID", False):
+            log.info("Using Google sub as unique user ID")
+            return response.get("sub")
+
+        log.info("Using email as user ID")
+        return details.get("email")
+
+
+def patch():
+    """Patch the GoogleOAuth2 class with our implementation."""
+    log.info("Applying IBLGoogleOAuth2 patch...")
+    try:
+        # Patch all possible import locations
+        from social_core.backends import google
+
+        log.info(f"Current GoogleOAuth2 class: {google.GoogleOAuth2}")
+
+        # Patch the class
+        google.GoogleOAuth2 = IBLGoogleOAuth2
+
+        log.info(f"After patching GoogleOAuth2: {google.GoogleOAuth2}")
+
+    except Exception as e:
+        log.error(f"Error during patching: {str(e)}", exc_info=True)
+        raise

--- a/src/ibl_third_party_auth/patches/patch_logoutview.py
+++ b/src/ibl_third_party_auth/patches/patch_logoutview.py
@@ -23,23 +23,35 @@ TPA_POST_LOGOUT_REDIRECT_URL = getattr(
 
 
 def dispatch(self, request, *args, **kwargs):
+    log.info(
+        "Starting logout process for user %s",
+        request.user.username if request.user.is_authenticated else "AnonymousUser",
+    )
+
     self.tpa_logout_url = tpa_pipeline.get_idp_logout_url_from_running_pipeline(request)
+    log.debug("IDP logout URL: %s", self.tpa_logout_url)
 
     logout(request)
+    log.info("User logged out from Django session")
+
     # Start IBL Patch
     if settings.ROOT_URLCONF.startswith("lms"):
+        log.debug("Using LMS logout flow")
         # For the LMS, we redirect to the normal logout page
         response = super(LogoutView, self).dispatch(request, *args, **kwargs)
     else:
+        log.debug("Using CMS logout flow")
         # CMS can't use the normal logout template b/c template exists in LMS
         # So we return a redirect to target after logging out
         context = self.get_context_data()
         target = context.get("target")
+        log.debug("Redirecting to target: %s", target)
         response = redirect(target)
     # End IBL Patch
 
     # Clear the cookie used by the edx.org marketing site
     delete_logged_in_cookies(response)
+    log.debug("Cleared marketing site cookies")
 
     mark_user_change_as_expected(None)
     return response
@@ -51,12 +63,15 @@ def get_context_data(self, **kwargs):
     context = self.orig_get_context_data(**kwargs)
     # Default behavior if no logout_url
     if not self.tpa_logout_url:
+        log.debug("No TPA logout URL found, using default context")
         return context
 
     end_session_url = self._add_post_logout_redirect_uri(self.tpa_logout_url)
     context["target"] = end_session_url
+    log.debug("Added end session URL to context: %s", end_session_url)
     # IBL PATCH ENDS
     return context
+
 
 # IBL PATCH STARTS
 def _add_post_logout_redirect_uri(self, end_session_url):
@@ -70,18 +85,24 @@ def _add_post_logout_redirect_uri(self, end_session_url):
     https://openid.net/specs/openid-connect-session-1_0.html#RedirectionAfterLogout
     """
     if not end_session_url or TPA_POST_LOGOUT_REDIRECT_URL is None:
+        log.debug("No end session URL or redirect URL configured")
         return end_session_url
 
     if TPA_POST_LOGOUT_REDIRECT_URL == "current_site":
         protocol = "https" if self.request.is_secure() else "http"
         url = "{}://{}".format(protocol, self.request.site.domain)
+        log.debug("Using current site as redirect URL: %s", url)
     else:
         url = TPA_POST_LOGOUT_REDIRECT_URL
+        log.debug("Using configured redirect URL: %s", url)
 
     redirect_uri = {TPA_POST_LOGOUT_REDIRECT_FIELD: url}
     query_string = urlencode(redirect_uri)
     end_session_url += "?{}".format(query_string)
+    log.debug("Final end session URL with redirect: %s", end_session_url)
     return end_session_url
+
+
 # IBL PATCH ENDS
 
 

--- a/src/ibl_third_party_auth/patches/patch_middleware.py
+++ b/src/ibl_third_party_auth/patches/patch_middleware.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any, Optional
 
 import six.moves.urllib.parse
 from common.djangoapps.student.helpers import get_next_url_for_login_page
@@ -17,29 +18,45 @@ log = logging.getLogger(__name__)
 class IBLExceptionMiddleware(SocialAuthExceptionMiddleware, MiddlewareMixin):
     """Custom middleware that handles conditional redirection."""
 
-    def get_redirect_uri(self, request, exception):
+    def get_redirect_uri(self, request: Any, exception: Exception) -> str:
+        """Get the redirect URI for the exception."""
+        log.debug(
+            "Getting redirect URI for exception",
+            extra={"exception_type": type(exception).__name__},
+        )
+
         # Fall back to django settings's SOCIAL_AUTH_LOGIN_ERROR_URL.
         redirect_uri = super().get_redirect_uri(request, exception)
 
-        # Safe because it's already been validated by
-        # pipeline.parse_query_params. If that pipeline step ever moves later
-        # in the pipeline stack, we'd need to validate this value because it
-        # would be an injection point for attacker data.
+        # Safe because it's already been validated by pipeline.parse_query_params
         auth_entry = request.session.get(pipeline.AUTH_ENTRY_KEY)
+        log.debug("Auth entry from session", extra={"auth_entry": auth_entry})
 
         # Check if we have an auth entry key we can use instead
         if auth_entry and auth_entry in pipeline.AUTH_DISPATCH_URLS:
             redirect_uri = pipeline.AUTH_DISPATCH_URLS[auth_entry]
+            log.debug("Using auth dispatch URL", extra={"redirect_uri": redirect_uri})
+
         return redirect_uri
 
-    def process_exception(self, request, exception):
+    def process_exception(self, request: Any, exception: Exception) -> Optional[Any]:
         """Handles specific exception raised by Python Social Auth eg HTTPError."""
-        log.exception(exception)
+        log.exception(
+            "Processing social auth exception",
+            extra={
+                "exception_type": type(exception).__name__,
+                "referer": request.META.get("HTTP_REFERER", ""),
+                "has_response": hasattr(exception, "response"),
+            },
+        )
+
         # Check if the exception has the 'response' attribute
-        if hasattr(exception, 'response'):
-            log.info(f"exception.response.content={exception.response.content}")
-        else:
-            log.info("Exception does not have a 'response' attribute.")
+        if hasattr(exception, "response"):
+            log.debug(
+                "Exception response content",
+                extra={"content": str(exception.response.content)},
+            )
+
         referer_url = request.META.get("HTTP_REFERER", "")
 
         if (
@@ -49,6 +66,13 @@ class IBLExceptionMiddleware(SocialAuthExceptionMiddleware, MiddlewareMixin):
         ):
             referer_url = six.moves.urllib.parse.urlparse(referer_url).path
             if referer_url == reverse("signin_user"):
+                log.warning(
+                    "502 error on signin page",
+                    extra={
+                        "referer_url": referer_url,
+                        "status_code": exception.response.status_code,
+                    },
+                )
                 messages.error(
                     request,
                     _("Unable to connect with the external provider, please try again"),
@@ -56,8 +80,16 @@ class IBLExceptionMiddleware(SocialAuthExceptionMiddleware, MiddlewareMixin):
                 )
                 redirect_url = get_next_url_for_login_page(request)
                 return redirect("/login?next=" + redirect_url)
+
         return super().process_exception(request, exception)
 
 
 def patch():
-    middleware.ExceptionMiddleware = IBLExceptionMiddleware
+    """Patch the middleware with our implementation."""
+    log.info("Starting middleware patch application")
+    try:
+        middleware.ExceptionMiddleware = IBLExceptionMiddleware
+        log.info("Successfully patched ExceptionMiddleware")
+    except Exception as e:
+        log.exception("Failed to apply middleware patch", extra={"error": str(e)})
+        raise

--- a/src/ibl_third_party_auth/registration.py
+++ b/src/ibl_third_party_auth/registration.py
@@ -71,7 +71,12 @@ class IblUserManagementView(APIView, IBLAppleIdAuth):
                     access_token=access_token,
                     algorithms=["RS256"],
                     issuer="https://accounts.google.com",
-                    options={"verify_sub": False, "verify_jti": False, "verify_at_hash": False, "verify_aud": False},
+                    options={
+                        "verify_sub": False,
+                        "verify_jti": False,
+                        "verify_at_hash": False,
+                        "verify_aud": False,
+                    },
                 )
             except Exception as e:
                 log.error(f"Error decoding token: {e}")
@@ -87,7 +92,9 @@ class IblUserManagementView(APIView, IBLAppleIdAuth):
             audience = provider.get_audience(backend)
 
             if claims["aud"] not in audience:
-                log.error(f"Error: Provided audience: {claims['aud']} is not in the list of valid audiences: {audience}")
+                log.error(
+                    f"Error: Provided audience: {claims['aud']} is not in the list of valid audiences: {audience}"
+                )
                 return False
 
             return claims
@@ -125,11 +132,15 @@ class IblUserManagementView(APIView, IBLAppleIdAuth):
             claims = jwt.get_unverified_claims(access_token)
             if isinstance(self.setting("AUDIENCE"), list):
                 if claims["aud"] not in self.setting("AUDIENCE"):
-                    log.error(f"Error: Provided audience: {claims['aud']} is not in the list of valid audiences: {self.setting('AUDIENCE')}")
+                    log.error(
+                        f"Error: Provided audience: {claims['aud']} is not in the list of valid audiences: {self.setting('AUDIENCE')}"
+                    )
                     return False
             else:
                 if claims["aud"] != self.setting("AUDIENCE"):
-                    log.error(f"Error: Provided audience: {claims['aud']} is not the valid audience: {self.setting('AUDIENCE')}")
+                    log.error(
+                        f"Error: Provided audience: {claims['aud']} is not the valid audience: {self.setting('AUDIENCE')}"
+                    )
                     return False
             if claims["exp"] < time.time():
                 log.error("Error: Token has expired")
@@ -196,7 +207,9 @@ class IblUserManagementView(APIView, IBLAppleIdAuth):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             try:
-                decoded_data = self.verify_google_jwt_token(id_token, access_token, backend)
+                decoded_data = self.verify_google_jwt_token(
+                    id_token, access_token, backend
+                )
                 if not decoded_data:
                     return Response(
                         {"error": "id_token could not be verified"},
@@ -227,6 +240,7 @@ class IblUserManagementView(APIView, IBLAppleIdAuth):
 
     def create_user_account(self, request, data={}, backend="apple-id"):
         import re
+
         if backend == "apple-id":
             params = request.data
             email = params.get("email")

--- a/src/ibl_third_party_auth/utils/user.py
+++ b/src/ibl_third_party_auth/utils/user.py
@@ -1,21 +1,59 @@
 import logging
 
 from common.djangoapps.student.models import UserProfile
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
+from django.core.exceptions import PermissionDenied
 from ibl_user_management_api.utils.main import retrieve_user
 
 log = logging.getLogger(__name__)
 
-class UserUtils():
+
+class UserUtils:
     def __init__(self):
         self.user_model = get_user_model()
 
     def create_user(self, username, email, first_name=None, last_name=None):
         """
-        Create a new user
+        Create a new user if allowed by settings.
+
+        Args:
+            username (str): The username for the new user
+            email (str): The email address for the new user
+            first_name (str, optional): The user's first name
+            last_name (str, optional): The user's last name
+
+        Returns:
+            bool: True if user was created, False if user already exists
+
+        Raises:
+            PermissionDenied: If user creation is disabled and user doesn't exist
         """
-        user, created = self.user_model.objects.get_or_create(username=username, email=email, first_name=first_name, last_name=last_name)
+        # First check if user already exists
+        existing_user = (
+            self.user_model.objects.filter(username=username).first()
+            or self.user_model.objects.filter(email=email).first()
+        )
+
+        if existing_user:
+            log.info(f"User already exists with username {username} or email {email}")
+            return False
+
+        # If user doesn't exist and creation is disabled, raise PermissionDenied
+        if getattr(settings, "SOCIAL_AUTH_DISABLE_USER_CREATION", False):
+            log.error(
+                f"User creation disabled. Cannot create user with username {username}"
+            )
+            raise PermissionDenied(
+                "User creation is currently disabled. Please contact support if you need access."
+            )
+
+        # Proceed with user creation since it's allowed
+        user, created = self.user_model.objects.get_or_create(
+            username=username, email=email, first_name=first_name, last_name=last_name
+        )
+
         if created:
             user = retrieve_user(username)
             if first_name and last_name:
@@ -24,7 +62,8 @@ class UserUtils():
             else:
                 profile = UserProfile(user=user, name=username)
             profile.save()
+            log.info(f"Successfully created new user with username {username}")
             return True
         else:
-            log.error("User already exists")
+            log.error(f"Failed to create user with username {username}")
             return False

--- a/src/ibl_third_party_auth/utils/user_platform_link.py
+++ b/src/ibl_third_party_auth/utils/user_platform_link.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from ibl_request_router.api.manager import manager_api_request
 
 logger = logging.getLogger(__name__)
@@ -17,11 +18,48 @@ def link_user_to_platform(user_id, platform_key):
     bool: True if the linking was successful (status code 200 or 201), False otherwise.
     """
     endpoint_path = "/core/users/platforms/"  # The function manager_api_request already appends /api to the Manager URLs
+
+    # First check if the link already exists
+    try:
+        check_response = manager_api_request(
+            "GET", f"{endpoint_path}?user_id={user_id}&platform_key={platform_key}"
+        )
+        link_exists = (
+            check_response
+            and check_response.status_code == 200
+            and check_response.json().get("results", [])
+        )
+
+        # If user creation is disabled and link doesn't exist, block new link creation
+        if (
+            getattr(settings, "SOCIAL_AUTH_DISABLE_USER_CREATION", False)
+            and not link_exists
+        ):
+            logger.warning(
+                f"New user platform linking disabled: SOCIAL_AUTH_DISABLE_USER_CREATION is True. "
+                f"Skipping new link creation for user {user_id} to platform {platform_key}"
+            )
+            return False
+
+        # If link already exists, return True
+        if link_exists:
+            logger.info(
+                f"Link already exists for user {user_id} to platform {platform_key}"
+            )
+            return True
+
+    except Exception as e:
+        logger.warning(
+            f"Error checking existing link for user {user_id} to platform {platform_key}: {str(e)}. "
+            "Proceeding with link attempt."
+        )
+
+    # Proceed with creating the link
     data = {
         "user_id": user_id,
         "platform_key": platform_key,
     }
-    logger.info(f"Linking user {user_id} to platform {platform_key}")
+    logger.info(f"Creating new link for user {user_id} to platform {platform_key}")
     try:
         response = manager_api_request("POST", endpoint_path, data=data)
         logger.info(f"Response: {response}")


### PR DESCRIPTION
## 2.1.0
### Added
- Add `SOCIAL_AUTH_DISABLE_USER_CREATION` flag to control user creation during SSO:
  - Implement user creation control in Apple ID authentication flow
  - Add comprehensive user existence verification:
    - Check by email address
    - Check by username (configurable via EMAIL_AS_USERNAME setting)
    - Check by social auth provider UID
  - Add detailed logging for authentication attempts:
    - Log user verification checks
    - Log successful matches
    - Log creation attempts when disabled
  - Implement clear error handling:
    - Raise PermissionDenied with informative messages
    - Guide users to contact support when needed
  - Maintain backward compatibility:
    - Allow existing users to continue logging in
    - Preserve all authentication paths for existing users
  - Update platform linking to respect user creation setting
  - Add documentation for the new setting and its usage